### PR TITLE
Remove unnecessary execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,20 @@ Helper to start multiple processes simultaneously.
 Lets start with an example:
 ```php
 $pool = new \Intermezzon\AsyncProcess\Pool();
-$pool->addCommand('php -r "echo \"Start process.\"; sleep(2); echo \"Process ended\";"')
-	->execute();
+$pool->addCommand('php -r "echo \"Start process.\"; sleep(2); echo \"Process ended\";"');
 
 // Wait for all commands to be done
-$pool->wait();
+$pool->executeAndWait();
 ```
 
 You may start multiple processes simultaneously
 ```php
 $pool = new \Intermezzon\AsyncProcess\Pool();
-$pool->addCommand('php -r "echo \"Start process 1.\n\"; sleep(2); echo \"Process 1 ended\n\";"')
-	->execute();
-$pool->addCommand('php -r "echo \"Start process 2.\n\"; sleep(1); echo \"Process 2 ended\n\";"')
-	->execute();
+$pool->addCommand('php -r "echo \"Start process 1.\n\"; sleep(2); echo \"Process 1 ended\n\";"');
+$pool->addCommand('php -r "echo \"Start process 2.\n\"; sleep(1); echo \"Process 2 ended\n\";"');
 
 // Wait for all commands to be done
-$pool->wait();
+$pool->executeAndWait();
 ```
 
 ## Events
@@ -43,11 +40,10 @@ $pool->addCommand('my_program')
 	->ended(function ($command, $exitCode) {
 		echo "Process ended with exit code: " . $exitCode . "\n";
 		echo "Process took " . $command->totalTime . " seconds to execute.";
-	})
-	->execute();
+	});
 
 // Wait for all commands to be done
-$pool->wait();
+$pool->executeAndWait();
 ```
 
 ## Settings

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -16,22 +16,20 @@ final class ProcessTest extends TestCase
 			$pool
 		);
 
-		$command = $pool->addCommand('php -r "echo \"output\";"')
-			->execute();
+		$command = $pool->addCommand('php -r "echo \"output\";"');
 
 		$this->assertIsObject(
 			$command
 		);
 
-		$pool->wait();
+		$pool->executeAndWait();
 	}
 
 	public function testOutput(): void
 	{
 		$pool = new \Intermezzon\AsyncProcess\Pool();
-		$command = $pool->addCommand('php -r "echo \"START-\"; echo \"END\";"')
-			->execute();
-		$pool->wait();
+		$command = $pool->addCommand('php -r "echo \"START-\"; echo \"END\";"');
+		$pool->executeAndWait();
 
 		$this->assertSame(
 			$command->out,
@@ -43,9 +41,8 @@ final class ProcessTest extends TestCase
 	{
 		$test = $this;
 		$pool = new \Intermezzon\AsyncProcess\Pool();
-		$command = $pool->addCommand('>&2 echo "error"')
-			->execute();
-		$pool->wait();
+		$command = $pool->addCommand('>&2 echo "error"');
+		$pool->executeAndWait();
 
 		$this->assertSame(
 			trim($command->err),
@@ -58,13 +55,12 @@ final class ProcessTest extends TestCase
 		$pool = new \Intermezzon\AsyncProcess\Pool();
 
 		for ($i = 0; $i < 5; $i++) {
-			$command = $pool->addCommand('php -r "echo \"START-\"; sleep(1); echo \"END\";"')
-				->execute();
+			$command = $pool->addCommand('php -r "echo \"START-\"; sleep(1); echo \"END\";"');
 			$this->assertIsObject(
 				$command
 			);
 		}
-		$pool->wait();
+		$pool->executeAndWait();
 
 	}
 
@@ -76,9 +72,8 @@ final class ProcessTest extends TestCase
 		$command = $pool->addCommand('exit 1')
 			->ended(function ($command, $rc) use (&$returnCode) {
 				$returnCode = $rc;
-			})
-			->execute();
-		$pool->wait();
+			});
+		$pool->executeAndWait();
 
 		$this->assertSame(
 			$returnCode,


### PR DESCRIPTION
 - Removes unnecessary execute-method.
 - Renames `$pool->wait()` to `$pool->executeAndWait()`

Fixes #1 

This will break backward compatibility and requires a new version